### PR TITLE
3.5.9

### DIFF
--- a/imap/builtins.py
+++ b/imap/builtins.py
@@ -32,10 +32,11 @@ def fetch_email_new(config, params, *args, **kwargs):
     """
     limit_count = params.get('limit_count', 30)
     parse_inline_image = params.get('parse_inline_image', False)
+    save_raw_email = params.get('save_raw_email', False)    
     client = _make_imap_client(config.get('host'), config.get('port'),
                                config.get('username'), config.get('password'), config.get('ssl'), config.get('verify'))
 
-    fetched_mails = _fetch_email(client, config.get('source'), config.get('destination'), limit_count, optimize=True, new=True, parse_inline_image=parse_inline_image, **kwargs)
+    fetched_mails = _fetch_email(client, config.get('source'), config.get('destination'), limit_count, optimize=True, new=True, parse_inline_image=parse_inline_image, save_raw_email=save_raw_email, **kwargs)
     logout_client(client)
     return fetched_mails
 

--- a/imap/fetch_mail_utility.py
+++ b/imap/fetch_mail_utility.py
@@ -6,6 +6,7 @@
 
 import email
 import json
+import random
 import ssl as ssl_lib
 from django.conf import settings
 from .errors.error_constants import *
@@ -13,6 +14,7 @@ from imapclient import IMAPClient
 from imapclient.exceptions import LoginError
 from connectors.core.connector import get_logger, ConnectorError
 from connectors.cyops_utilities.builtins import explode_email
+from integrations.crudhub import make_request
 
 logger = get_logger("builtins.imap")
 
@@ -25,6 +27,37 @@ except:
 
 # py 3.6 when
 DISPLAY_SIZE_LIMIT = 20000
+
+
+def upload_file_to_cyops(file_name, file_content, file_description):
+    try:
+        # Conditional import based on the FortiSOAR version.
+        try:
+            from integrations.crudhub import make_file_upload_request
+            response = make_file_upload_request(file_name, file_content, 'application/octet-stream')
+
+        except:
+            from cshmac.requests import HmacAuth
+            from integrations.crudhub import maybe_json_or_raise
+            from requests import post
+
+            url = settings.CRUD_HUB_URL + '/api/3/files'
+            auth = HmacAuth(url, 'POST', settings.APPLIANCE_PUBLIC_KEY,
+                            settings.APPLIANCE_PRIVATE_KEY,
+                            settings.APPLIANCE_PUBLIC_KEY.encode('utf-8'))
+            files = {'file': (file_name, file_content, {'Expire': 0})}
+            response = post(url, auth=auth, files=files, verify=False)
+            response = maybe_json_or_raise(response)
+
+        logger.info('File upload complete {0}'.format(str(response)))
+        file_id = response['@id']
+        attach_response = make_request('/api/3/attachments', 'POST',
+                                       {'name': file_name, 'file': file_id, 'description': file_description })
+        logger.info('attach file completed: {0}'.format(attach_response))
+        return attach_response
+    except Exception as err:
+        logger.exception('An exception occurred {0}'.format(str(err)))
+        raise ConnectorError('An exception occurred {0}'.format(str(err)))
 
 
 def _make_imap_client(host, port, username, password, ssl, verify):
@@ -100,6 +133,13 @@ def _fetch_email(client, source, destination, limit_count=30, optimize=False, pa
             email_data = _parse_email_old(client, data)
         # move the email to another folder
         _move_email(client, msgid, source, destination)
+        # upload raw email to cyops if needed
+        save_raw_email = kwargs.get('save_raw_email', False)
+        if save_raw_email:
+            email_id = email_data['headers'].get('message-id', 'email-'+str(random.randrange(10000, 99999)))
+            attachment = upload_file_to_cyops(email_id, raw_msg, f"RFC822 of email: {email_id}")
+            email_data['headers'].update({'rfc822_attachment':attachment})
+
         # build up list of emails
         email_data['total_unread_emails'] = unread_mails_count
         emails.append(email_data)

--- a/imap/info.json
+++ b/imap/info.json
@@ -203,7 +203,7 @@
           "value": true
         },
         {
-          "title": "Save raw email as attachment",
+          "title": "Save Raw Email as Attachment",
           "tooltip": "Saves the raw RFC822 email as attachment",
           "name": "save_raw_email",
           "type": "checkbox",

--- a/imap/info.json
+++ b/imap/info.json
@@ -1,13 +1,14 @@
 {
   "name": "imap",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "label": "IMAP",
   "description": "Steps related to fetching and parsing email",
   "publisher": "Fortinet",
+  "contributor": "Naili.M",
   "cs_approved": true,
   "cs_compatible": true,
   "category": "utilities",
-  "help_online": "https://docs.fortinet.com/document/fortisoar/3.5.8/imap-connector/969/imap-connector-v3-5-8",
+  "help_online": "https://docs.fortinet.com/document/fortisoar/3.5.9/imap-connector/969/imap-connector-v3.5.9",
   "icon_small_name": "imap_small.png",
   "icon_large_name": "imap_large.png",
   "ingestion_supported": true,
@@ -200,7 +201,17 @@
           "editable": true,
           "required": false,
           "value": true
-        }
+        },
+        {
+          "title": "Save raw email as attachment",
+          "tooltip": "Saves the raw RFC822 email as attachment",
+          "name": "save_raw_email",
+          "type": "checkbox",
+          "visible": true,
+          "editable": true,
+          "required": false,
+          "value": false
+        }        
       ],
       "output_schema": [
         {

--- a/imap/playbooks/playbooks.json
+++ b/imap/playbooks/playbooks.json
@@ -3,11 +3,13 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - IMAP - 3.5.8",
+      "name": "Sample - IMAP - 3.5.9",
       "description": "Sample playbooks for \"IMAP\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
-      "image": "imap_medium.png",
       "uuid": "aeb40806-3531-487e-b567-15e3b130dec5",
+      "id": 4,
+      "deletedAt": null,
+      "importedBy": [],
       "recordTags": [],
       "workflows": [
         {
@@ -15,158 +17,30 @@
           "triggerLimit": null,
           "name": "IMAP > Ingest",
           "aliasName": null,
-          "description": "Fetches Email from IMAP",
-          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
           "tag": "#imap #dataingestion #ingest #create",
+          "description": "Fetches Email from IMAP",
           "isActive": false,
+          "debug": false,
           "singleRecordExecution": false,
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
+          "lastModifyDate": 1737620625,
+          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
+          "versions": [],
           "triggerStep": "/api/3/workflow_steps/ff54e698-3d97-4fd8-bbbc-891de63f7436",
           "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Create Record",
-              "description": "Create Alert Records for the Emails received",
-              "arguments": {
-                "for_each": {
-                  "item": "{{vars.steps.Fetch_Emails.data}}",
-                  "__bulk": true,
-                  "parallel": false,
-                  "condition": "{{(vars.item[\"body\"][\"html\"] | regex_search('(?<=FSR)(.*?)(?=FSR)')) is none}}"
-                },
-                "resource": {
-                  "name": "{% if vars.item.headers.subject %} {{vars.item.headers.subject}} {% else %} None {% endif %}",
-                  "type": {
-                    "id": 121,
-                    "@id": "/api/3/picklists/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
-                    "icon": null,
-                    "@type": "Picklist",
-                    "color": null,
-                    "display": "Phishing",
-                    "listName": "/api/3/picklist_names/a7087b9c-5660-495f-a8ac-c3b198ddb8c2",
-                    "itemValue": "Phishing",
-                    "orderIndex": 7
-                  },
-                  "source": "{% if  'reporterEmailAddress' in vars.item %}User Reported{% else %}Email Server{% endif %}",
-                  "emailTo": "{{vars.item.headers.to}}",
-                  "fileHash": "{% if vars.item.attachments | json_query(\"[*].metadata.md5\") | join(',') %}{{vars.item.attachments | json_query(\"[*].metadata.md5\") | join(', ')}}{%else%}NA{% endif%}",
-                  "reporter": "{% if 'reporterEmailAddress' in vars.item %}{{ vars.item.reporterEmailAddress }}{% endif %}",
-                  "severity": {
-                    "id": 65,
-                    "@id": "/api/3/picklists/0d609b08-45e0-469f-8910-41145c0b7c03",
-                    "icon": null,
-                    "@type": "Picklist",
-                    "color": "#157DD9",
-                    "display": "Minimal",
-                    "listName": "/api/3/picklist_names/4e80cba3-032f-48b4-ac03-17e3ec247aac",
-                    "itemValue": "Minimal",
-                    "orderIndex": 0
-                  },
-                  "sourceId": "{{ vars.item.headers['message-id'] | join }}",
-                  "__replace": "false",
-                  "emailBody": "{%if vars.item['body']['html'] %}{{vars.item['body']['html']}}{%else%}{{vars.item['body']['text']}}{% endif %}",
-                  "emailFrom": "{{vars.item.headers.from}}",
-                  "fileNames": "{% if vars.item.attachments | json_query(\"[*].metadata.filename\") | join(',') %}{{vars.item.attachments | json_query(\"[*].metadata.filename\") | join(', ')}}{%else%}NA{% endif%}",
-                  "returnPath": "{{ vars.item.headers['return-path'] }}",
-                  "sourcedata": "{{ vars.item | toJSON }}",
-                  "emailHeaders": "{{ vars.item.headers | toJSON }}",
-                  "emailSubject": "{{vars.item.headers.subject}}",
-                  "senderDomain": "{% if vars.item.headers.from %}{{(vars.item.headers.from.split('<')[-1] | replace(\">\",\"\")).split('@')[-1] | replace(\">\",\"\")}}{% endif %}",
-                  "reporterEmailBody": "<p>{% if 'reporterEmailBody' in vars.item %}{{ vars.item.reporterEmailBody.html }}{% endif %}</p>",
-                  "senderEmailAddress": "{% if vars.item.headers.from %}{{vars.item.headers.from.split('<')[-1] | replace(\">\",\"\")}}{% endif %}",
-                  "recipientEmailAddress": "{% if vars.item.headers['to'] is not string %}{{vars.item.headers['to'] | join(',') }}{%else%}{{vars.item.headers['to']}}{% endif%}"
-                },
-                "_showJson": false,
-                "operation": "Overwrite",
-                "collection": "/api/3/upsert/alerts",
-                "fieldOperation": {
-                  "recordTags": "Overwrite"
-                },
-                "step_variables": []
-              },
-              "status": null,
-              "left": "774",
-              "top": "420",
-              "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-              "uuid": "b682d9bf-82fb-44a3-961b-74d7ccfdb892"
-            },
             {
               "@type": "WorkflowStep",
               "name": "Configuration",
               "description": null,
               "arguments": [],
               "status": null,
-              "left": "260",
               "top": "140",
+              "left": "260",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
               "uuid": "13363b4c-37b4-44c2-9564-a0e5b66bd9fc"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Extract and Link File Indicators",
-              "description": null,
-              "arguments": {
-                "for_each": {
-                  "item": "{{ vars.steps.Create_Record }}",
-                  "condition": "{{(vars.item.sourcedata | from_json).attachments and (vars.item.createDate == vars.item.modifyDate)}}"
-                },
-                "arguments": {
-                  "assetIRI": "",
-                  "attachments": "{{ (vars.item.sourcedata | from_json).attachments }}",
-                  "alertRecordIRI": "{{vars.item['@id']}}",
-                  "emailRecordIRI": "",
-                  "fileIndicatorType": "{{vars.fileIndicatorType}}",
-                  "incidentRecordIRI": ""
-                },
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/ec9a21d1-94c0-42af-8a9f-fcdb2e8c4663"
-              },
-              "status": null,
-              "left": "934",
-              "top": "520",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "671f47ad-4f85-45f9-b15e-732c363ba54e"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Fetch Emails",
-              "description": null,
-              "arguments": {
-                "arguments": [],
-                "step_variables": [],
-                "workflowReference": "/api/3/workflows/ad801770-b8cf-4369-8ce4-bf3ff1097daf"
-              },
-              "status": null,
-              "left": "446",
-              "top": "240",
-              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-              "uuid": "f9f8271e-d9d0-473c-8b53-9bc7487673df"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "route": "fetch_emails_imap",
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "api_body": "{{vars.request.data}}"
-                    }
-                  },
-                  "fileIndicatorType": "{{(\"IndicatorType\" | picklist(\"File\"))[\"@id\"]}}"
-                },
-                "authentication_methods": [
-                  ""
-                ]
-              },
-              "status": null,
-              "left": "60",
-              "top": "53",
-              "stepType": "/api/3/workflow_step_types/df26c7a2-4166-4ca5-91e5-548e24c01b5f",
-              "uuid": "ff54e698-3d97-4fd8-bbbc-891de63f7436"
             },
             {
               "@type": "WorkflowStep",
@@ -219,101 +93,240 @@
                 "step_variables": []
               },
               "status": null,
-              "left": "620",
               "top": "320",
+              "left": "620",
               "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
+              "group": null,
               "uuid": "aed29d7c-67c8-447e-977f-21ee13ce1d99"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Create Record",
+              "description": "Create Alert Records for the Emails received",
+              "arguments": {
+                "for_each": {
+                  "item": "{{vars.steps.Fetch_Emails.data}}",
+                  "__bulk": true,
+                  "parallel": false,
+                  "condition": "{{(vars.item[\"body\"][\"html\"] | regex_search('(?<=FSR)(.*?)(?=FSR)')) is none}}",
+                  "batch_size": 100
+                },
+                "resource": {
+                  "name": "{% if vars.item.headers.subject %} {{vars.item.headers.subject}} {% else %} None {% endif %}",
+                  "type": "/api/3/picklists/0b3ef6f9-eb29-4ab9-ac98-98364bd1a3aa",
+                  "state": "/api/3/picklists/a1bac09b-1441-45aa-ad1b-c88744e48e72",
+                  "source": "{% if  'reporterEmailAddress' in vars.item %}User Reported{% else %}Email Server{% endif %}",
+                  "status": "/api/3/picklists/7de816ff-7140-4ee5-bd05-93ce22002146",
+                  "emailTo": "{{vars.item.headers.to}}",
+                  "fileHash": "{% if vars.item.attachments | json_query(\"[*].metadata.md5\") | join(',') %}{{vars.item.attachments | json_query(\"[*].metadata.md5\") | join(', ')}}{%else%}NA{% endif%}",
+                  "reporter": "{% if 'reporterEmailAddress' in vars.item %}{{ vars.item.reporterEmailAddress }}{% endif %}",
+                  "severity": "/api/3/picklists/0d609b08-45e0-469f-8910-41145c0b7c03",
+                  "sourceId": "{{ vars.item.headers['message-id'] | join }}",
+                  "__replace": "false",
+                  "emailBody": "{%if vars.item['body']['html'] %}{{vars.item['body']['html']}}{%else%}{{vars.item['body']['text']}}{% endif %}",
+                  "emailFrom": "{{vars.item.headers.from}}",
+                  "fileNames": "{% if vars.item.attachments | json_query(\"[*].metadata.filename\") | join(',') %}{{vars.item.attachments | json_query(\"[*].metadata.filename\") | join(', ')}}{%else%}NA{% endif%}",
+                  "returnPath": "{{ vars.item.headers['return-path'] }}",
+                  "sourcedata": "{{ vars.item | toJSON }}",
+                  "attachments": "{{vars.item.headers.rfc822_attachment['@id']}}",
+                  "ackSlaStatus": "/api/3/picklists/72979f64-e8b9-4888-a965-957e0ec24818",
+                  "emailHeaders": "{{ vars.item.headers | toJSON }}",
+                  "emailSubject": "{{vars.item.headers.subject}}",
+                  "senderDomain": "{% if vars.item.headers.from %}{{(vars.item.headers.from.split('<')[-1] | replace(\">\",\"\")).split('@')[-1] | replace(\">\",\"\")}}{% endif %}",
+                  "respSlaStatus": "/api/3/picklists/72979f64-e8b9-4888-a965-957e0ec24818",
+                  "priorityWeight": 1,
+                  "reporterEmailBody": "<p>{% if 'reporterEmailBody' in vars.item %}{{ vars.item.reporterEmailBody.html }}{% endif %}</p>",
+                  "senderEmailAddress": "{% if vars.item.headers.from %}{{vars.item.headers.from.split('<')[-1] | replace(\">\",\"\")}}{% endif %}",
+                  "escalatedtoincident": "/api/3/picklists/2128a09c-153d-4db3-985d-de6be33deae5",
+                  "resolvedAutomatedly": false,
+                  "alertRemainingAckSLA": 0,
+                  "recipientEmailAddress": "{% if vars.item.headers['to'] is not string %}{{vars.item.headers['to'] | join(',') }}{%else%}{{vars.item.headers['to']}}{% endif%}"
+                },
+                "_showJson": false,
+                "operation": "Overwrite",
+                "collection": "/api/3/upsert/alerts",
+                "__recommend": [],
+                "fieldOperation": {
+                  "recordTags": "Overwrite"
+                },
+                "step_variables": []
+              },
+              "status": null,
+              "top": "420",
+              "left": "774",
+              "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
+              "group": null,
+              "uuid": "b682d9bf-82fb-44a3-961b-74d7ccfdb892"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Extract and Link File Indicators",
+              "description": null,
+              "arguments": {
+                "for_each": {
+                  "item": "{{ vars.steps.Create_Record }}",
+                  "condition": "{{(vars.item.sourcedata | from_json).attachments and (vars.item.createDate == vars.item.modifyDate)}}"
+                },
+                "arguments": {
+                  "assetIRI": "",
+                  "attachments": "{{ (vars.item.sourcedata | from_json).attachments }}",
+                  "alertRecordIRI": "{{vars.item['@id']}}",
+                  "emailRecordIRI": "",
+                  "fileIndicatorType": "{{vars.fileIndicatorType}}",
+                  "incidentRecordIRI": ""
+                },
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/ec9a21d1-94c0-42af-8a9f-fcdb2e8c4663"
+              },
+              "status": null,
+              "top": "520",
+              "left": "934",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "671f47ad-4f85-45f9-b15e-732c363ba54e"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Fetch Emails",
+              "description": null,
+              "arguments": {
+                "arguments": [],
+                "step_variables": [],
+                "workflowReference": "/api/3/workflows/ad801770-b8cf-4369-8ce4-bf3ff1097daf"
+              },
+              "status": null,
+              "top": "240",
+              "left": "446",
+              "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
+              "uuid": "f9f8271e-d9d0-473c-8b53-9bc7487673df"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "route": "fetch_emails_imap",
+                "step_variables": {
+                  "input": {
+                    "params": {
+                      "api_body": "{{vars.request.data}}"
+                    }
+                  },
+                  "fileIndicatorType": "{{(\"IndicatorType\" | picklist(\"File\"))[\"@id\"]}}"
+                },
+                "authentication_methods": [
+                  ""
+                ]
+              },
+              "status": null,
+              "top": "53",
+              "left": "60",
+              "stepType": "/api/3/workflow_step_types/df26c7a2-4166-4ca5-91e5-548e24c01b5f",
+              "group": null,
+              "uuid": "ff54e698-3d97-4fd8-bbbc-891de63f7436"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "a05c75bb-66d1-48e0-9959-2bb6cf28f831",
-              "name": "Create Record -> Extract and Link File Indicators",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/671f47ad-4f85-45f9-b15e-732c363ba54e",
-              "sourceStep": "/api/3/workflow_steps/b682d9bf-82fb-44a3-961b-74d7ccfdb892"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "0239bc06-42d6-4f16-81c7-359003c25184",
-              "name": "Start -> Configuration",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/13363b4c-37b4-44c2-9564-a0e5b66bd9fc",
-              "sourceStep": "/api/3/workflow_steps/ff54e698-3d97-4fd8-bbbc-891de63f7436"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "87c2a057-50b7-4b7b-9feb-0ae307ec899b",
               "name": "Configuration -> Fetch Emails",
-              "label": null,
-              "isExecuted": false,
               "targetStep": "/api/3/workflow_steps/f9f8271e-d9d0-473c-8b53-9bc7487673df",
-              "sourceStep": "/api/3/workflow_steps/13363b4c-37b4-44c2-9564-a0e5b66bd9fc"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "46cd49db-6137-45f1-9b9a-4f670d7b5210",
-              "name": "Fetch Emails -> Create Communications Record",
+              "sourceStep": "/api/3/workflow_steps/13363b4c-37b4-44c2-9564-a0e5b66bd9fc",
               "label": null,
               "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/aed29d7c-67c8-447e-977f-21ee13ce1d99",
-              "sourceStep": "/api/3/workflow_steps/f9f8271e-d9d0-473c-8b53-9bc7487673df"
+              "group": null,
+              "uuid": "87c2a057-50b7-4b7b-9feb-0ae307ec899b"
             },
             {
               "@type": "WorkflowRoute",
-              "uuid": "21ba0866-0fd6-4d7e-b211-ff8154f53655",
               "name": "Create Communications Record -> Create Record",
+              "targetStep": "/api/3/workflow_steps/b682d9bf-82fb-44a3-961b-74d7ccfdb892",
+              "sourceStep": "/api/3/workflow_steps/aed29d7c-67c8-447e-977f-21ee13ce1d99",
               "label": null,
               "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/b682d9bf-82fb-44a3-961b-74d7ccfdb892",
-              "sourceStep": "/api/3/workflow_steps/aed29d7c-67c8-447e-977f-21ee13ce1d99"
+              "group": null,
+              "uuid": "21ba0866-0fd6-4d7e-b211-ff8154f53655"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Create Record -> Extract and Link File Indicators",
+              "targetStep": "/api/3/workflow_steps/671f47ad-4f85-45f9-b15e-732c363ba54e",
+              "sourceStep": "/api/3/workflow_steps/b682d9bf-82fb-44a3-961b-74d7ccfdb892",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "a05c75bb-66d1-48e0-9959-2bb6cf28f831"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Fetch Emails -> Create Communications Record",
+              "targetStep": "/api/3/workflow_steps/aed29d7c-67c8-447e-977f-21ee13ce1d99",
+              "sourceStep": "/api/3/workflow_steps/f9f8271e-d9d0-473c-8b53-9bc7487673df",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "46cd49db-6137-45f1-9b9a-4f670d7b5210"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Configuration",
+              "targetStep": "/api/3/workflow_steps/13363b4c-37b4-44c2-9564-a0e5b66bd9fc",
+              "sourceStep": "/api/3/workflow_steps/ff54e698-3d97-4fd8-bbbc-891de63f7436",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "0239bc06-42d6-4f16-81c7-359003c25184"
             }
           ],
-          "versions": [],
-          "lastModifyDate": 1600772683,
+          "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "6ec03813-718a-43d5-be57-b93962c6b8dd",
+          "id": 19,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
           "recordTags": [
+            "create",
             "dataingestion",
             "imap",
-            "create",
             "ingest"
-          ],
-          "isPrivate": false,
-          "owners": []
+          ]
         },
         {
           "@type": "Workflow",
           "triggerLimit": null,
           "name": "> IMAP > Fetch",
           "aliasName": null,
-          "description": "Fetches Email from IMAP",
-          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
           "tag": "#imap #dataingestion #fetch",
+          "description": "Fetches Email from IMAP",
           "isActive": false,
+          "debug": false,
           "singleRecordExecution": false,
           "remoteExecutableFlag": false,
           "parameters": [],
           "synchronous": false,
+          "lastModifyDate": 1600772757,
+          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
+          "versions": [],
           "triggerStep": "/api/3/workflow_steps/42d7e031-25cc-4c8d-9fed-a35387bae49d",
           "steps": [
             {
               "@type": "WorkflowStep",
-              "name": "Start",
+              "name": "Configuration",
               "description": null,
               "arguments": {
-                "step_variables": {
-                  "_configuration_schema": "[\n{\n    \"title\": \"Use Unified Communication\",\n    \"name\": \"use_communications\",\n    \"type\": \"checkbox\",\n    \"tooltip\": \"Select this option to create a record of the retrieved email in the Communication Module.\",\n    \"required\": false,\n    \"editable\": true,\n    \"visible\": true,\n    \"value\": true\n  }\n]"
-                }
+                "use_communications": "true"
               },
               "status": null,
-              "left": "60",
-              "top": "52",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "42d7e031-25cc-4c8d-9fed-a35387bae49d"
+              "top": "140",
+              "left": "228",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "b63a432c-29c8-44a0-9dd2-7dc36a13a9d6"
             },
             {
               "@type": "WorkflowStep",
@@ -325,31 +338,18 @@
                 "params": {
                   "parse_inline_image": true
                 },
-                "version": "3.5.8",
+                "version": "3.5.9",
                 "connector": "imap",
                 "operation": "fetch_email_new",
                 "operationTitle": "Fetch Email(s)",
                 "step_variables": []
               },
               "status": null,
-              "left": "386",
               "top": "260",
+              "left": "386",
               "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+              "group": null,
               "uuid": "e42c83bc-19b4-4f2d-bbdc-3defac25ed14"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Set Consolidated Result",
-              "description": null,
-              "arguments": {
-                "data": "{{ vars.steps.Process_emails | json_query('[].processed_email[]') }}",
-                "use_communications": "{{vars.use_communications}}"
-              },
-              "status": null,
-              "left": "700",
-              "top": "469",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "c62f5818-5083-41a4-84c2-92be3da76e84"
             },
             {
               "@type": "WorkflowStep",
@@ -368,84 +368,111 @@
                 "workflowReference": "/api/3/workflows/eeaf0280-2085-4beb-808b-a9abda63cfad"
               },
               "status": null,
-              "left": "555",
               "top": "360",
+              "left": "555",
               "stepType": "/api/3/workflow_step_types/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+              "group": null,
               "uuid": "cbee4b5f-fb78-4fa5-840d-8c78aa259e08"
             },
             {
               "@type": "WorkflowStep",
-              "name": "Configuration",
+              "name": "Set Consolidated Result",
               "description": null,
               "arguments": {
-                "use_communications": "true"
+                "data": "{{ vars.steps.Process_emails | json_query('[].processed_email[]') }}",
+                "use_communications": "{{vars.use_communications}}"
               },
               "status": null,
-              "left": "228",
-              "top": "140",
+              "top": "469",
+              "left": "700",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "b63a432c-29c8-44a0-9dd2-7dc36a13a9d6"
+              "group": null,
+              "uuid": "c62f5818-5083-41a4-84c2-92be3da76e84"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "_configuration_schema": "[\n{\n    \"title\": \"Use Unified Communication\",\n    \"name\": \"use_communications\",\n    \"type\": \"checkbox\",\n    \"tooltip\": \"Select this option to create a record of the retrieved email in the Communication Module.\",\n    \"required\": false,\n    \"editable\": true,\n    \"visible\": true,\n    \"value\": true\n  }\n]"
+                }
+              },
+              "status": null,
+              "top": "52",
+              "left": "60",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "42d7e031-25cc-4c8d-9fed-a35387bae49d"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "9abd09d8-54b5-4fa4-8bcd-eafabb32d103",
-              "name": "Fetch emails -> Process Email",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/cbee4b5f-fb78-4fa5-840d-8c78aa259e08",
-              "sourceStep": "/api/3/workflow_steps/e42c83bc-19b4-4f2d-bbdc-3defac25ed14"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "9a315e34-49b3-4d93-9925-256acccafe9f",
-              "name": "Process Email -> Set Consolidated Result",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/c62f5818-5083-41a4-84c2-92be3da76e84",
-              "sourceStep": "/api/3/workflow_steps/cbee4b5f-fb78-4fa5-840d-8c78aa259e08"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "cdff1913-9bdb-4a41-a24d-9de3166e48a9",
-              "name": "Start -> Configuration",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/b63a432c-29c8-44a0-9dd2-7dc36a13a9d6",
-              "sourceStep": "/api/3/workflow_steps/42d7e031-25cc-4c8d-9fed-a35387bae49d"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "596fe0e7-35a3-42d5-bbb9-3f8c430b86fb",
               "name": "Configuration -> Fetch emails",
+              "targetStep": "/api/3/workflow_steps/e42c83bc-19b4-4f2d-bbdc-3defac25ed14",
+              "sourceStep": "/api/3/workflow_steps/b63a432c-29c8-44a0-9dd2-7dc36a13a9d6",
               "label": null,
               "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/e42c83bc-19b4-4f2d-bbdc-3defac25ed14",
-              "sourceStep": "/api/3/workflow_steps/b63a432c-29c8-44a0-9dd2-7dc36a13a9d6"
+              "group": null,
+              "uuid": "596fe0e7-35a3-42d5-bbb9-3f8c430b86fb"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Fetch emails -> Process Email",
+              "targetStep": "/api/3/workflow_steps/cbee4b5f-fb78-4fa5-840d-8c78aa259e08",
+              "sourceStep": "/api/3/workflow_steps/e42c83bc-19b4-4f2d-bbdc-3defac25ed14",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "9abd09d8-54b5-4fa4-8bcd-eafabb32d103"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Process Email -> Set Consolidated Result",
+              "targetStep": "/api/3/workflow_steps/c62f5818-5083-41a4-84c2-92be3da76e84",
+              "sourceStep": "/api/3/workflow_steps/cbee4b5f-fb78-4fa5-840d-8c78aa259e08",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "9a315e34-49b3-4d93-9925-256acccafe9f"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Configuration",
+              "targetStep": "/api/3/workflow_steps/b63a432c-29c8-44a0-9dd2-7dc36a13a9d6",
+              "sourceStep": "/api/3/workflow_steps/42d7e031-25cc-4c8d-9fed-a35387bae49d",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "cdff1913-9bdb-4a41-a24d-9de3166e48a9"
             }
           ],
-          "versions": [],
-          "lastModifyDate": 1600772757,
+          "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "ad801770-b8cf-4369-8ce4-bf3ff1097daf",
+          "id": 20,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
           "recordTags": [
             "dataingestion",
-            "imap",
-            "fetch"
-          ],
-          "isPrivate": false,
-          "owners": []
+            "fetch",
+            "imap"
+          ]
         },
         {
           "@type": "Workflow",
           "triggerLimit": null,
           "name": "> IMAP > Extract Indicators",
           "aliasName": null,
-          "description": "Create an Alert from Ingested Email Record",
-          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
           "tag": "#imap #dataingestion",
+          "description": "Create an Alert from Ingested Email Record",
           "isActive": false,
+          "debug": false,
           "singleRecordExecution": false,
           "remoteExecutableFlag": false,
           "parameters": [
@@ -457,36 +484,11 @@
             "assetIRI"
           ],
           "synchronous": false,
+          "lastModifyDate": 1579790520,
+          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
+          "versions": [],
           "triggerStep": "/api/3/workflow_steps/4772c807-7fc2-4575-a278-1e43cdb4c851",
           "steps": [
-            {
-              "@type": "WorkflowStep",
-              "name": "Upload File IOCs",
-              "description": null,
-              "arguments": {
-                "params": {
-                  "filename": "{{vars.item.metadata.filename}}",
-                  "file_path": "{{vars.item.file}}",
-                  "create_attachment": false
-                },
-                "version": "3.0.0",
-                "for_each": {
-                  "item": "{{ vars.attachments }}",
-                  "__bulk": false,
-                  "parallel": false,
-                  "condition": ""
-                },
-                "connector": "cyops_utilities",
-                "operation": "upload_file_to_cyops",
-                "operationTitle": "File: Upload a file to CyOPs and Create an Attachment",
-                "step_variables": []
-              },
-              "status": null,
-              "left": "380",
-              "top": "120",
-              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-              "uuid": "5b050515-1c65-43f8-990f-2a01c2dbee18"
-            },
             {
               "@type": "WorkflowStep",
               "name": "Create Indicators",
@@ -523,36 +525,11 @@
                 "step_variables": []
               },
               "status": null,
-              "left": "720",
               "top": "210",
+              "left": "720",
               "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
+              "group": null,
               "uuid": "d7a81d72-9552-4321-8bb2-00160b603932"
-            },
-            {
-              "@type": "WorkflowStep",
-              "name": "Start",
-              "description": null,
-              "arguments": {
-                "step_variables": {
-                  "input": {
-                    "params": {
-                      "assetIRI": "{{ vars.assetIRI }}",
-                      "fileType": "{{ vars.fileType }}",
-                      "sourcedata": "{{ vars.sourcedata }}",
-                      "attachments": "{{ vars.attachments }}",
-                      "alertRecordIRI": "{{ vars.alertRecordIRI }}",
-                      "emailRecordIRI": "{{ vars.emailRecordIRI }}",
-                      "fileIndicatorType": "{{ vars.fileIndicatorType }}",
-                      "incidentRecordIRI": "{{ vars.incidentRecordIRI }}"
-                    }
-                  }
-                }
-              },
-              "status": null,
-              "left": "20",
-              "top": "26",
-              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "4772c807-7fc2-4575-a278-1e43cdb4c851"
             },
             {
               "@type": "WorkflowStep",
@@ -582,69 +559,12 @@
                 "step_variables": []
               },
               "status": null,
-              "left": "1013",
               "top": "300",
+              "left": "1013",
               "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928722",
+              "group": null,
               "uuid": "60431ea2-fdce-4b8c-be96-7971a3bf362c"
-            }
-          ],
-          "routes": [
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "3ce9dec3-64dd-4e5d-95eb-8e74cad8824c",
-              "name": "Upload File IOCs -> Create and Link File Indicators",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/d7a81d72-9552-4321-8bb2-00160b603932",
-              "sourceStep": "/api/3/workflow_steps/5b050515-1c65-43f8-990f-2a01c2dbee18"
             },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "a41ca26a-9e84-4669-b841-daff37945e8a",
-              "name": "Create and Link File Indicators -> Link Indicators",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/60431ea2-fdce-4b8c-be96-7971a3bf362c",
-              "sourceStep": "/api/3/workflow_steps/d7a81d72-9552-4321-8bb2-00160b603932"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "e437fc87-4c2a-442b-aef8-e2db1e26c0ff",
-              "name": "Start -> Upload File IOCs",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/5b050515-1c65-43f8-990f-2a01c2dbee18",
-              "sourceStep": "/api/3/workflow_steps/4772c807-7fc2-4575-a278-1e43cdb4c851"
-            }
-          ],
-          "versions": [],
-          "lastModifyDate": 1579790520,
-          "priority": null,
-          "uuid": "ec9a21d1-94c0-42af-8a9f-fcdb2e8c4663",
-          "recordTags": [
-            "dataingestion",
-            "imap"
-          ],
-          "isPrivate": false,
-          "owners": []
-        },
-        {
-          "@type": "Workflow",
-          "triggerLimit": null,
-          "name": ">> IMAP > Process Email",
-          "aliasName": null,
-          "description": "Extract IMAP Email and checks if msg/eml file is present",
-          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
-          "tag": "#imap #dataingestion",
-          "isActive": false,
-          "singleRecordExecution": false,
-          "remoteExecutableFlag": false,
-          "parameters": [
-            "email"
-          ],
-          "synchronous": false,
-          "triggerStep": "/api/3/workflow_steps/2f8ea211-977b-4077-8ccf-8380fccf6d09",
-          "steps": [
             {
               "@type": "WorkflowStep",
               "name": "Start",
@@ -653,57 +573,122 @@
                 "step_variables": {
                   "input": {
                     "params": {
-                      "email": "{{ vars.email }}"
+                      "assetIRI": "{{ vars.assetIRI }}",
+                      "fileType": "{{ vars.fileType }}",
+                      "sourcedata": "{{ vars.sourcedata }}",
+                      "attachments": "{{ vars.attachments }}",
+                      "alertRecordIRI": "{{ vars.alertRecordIRI }}",
+                      "emailRecordIRI": "{{ vars.emailRecordIRI }}",
+                      "fileIndicatorType": "{{ vars.fileIndicatorType }}",
+                      "incidentRecordIRI": "{{ vars.incidentRecordIRI }}"
                     }
                   }
                 }
               },
               "status": null,
-              "left": "60",
-              "top": "40",
+              "top": "26",
+              "left": "20",
               "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-              "uuid": "2f8ea211-977b-4077-8ccf-8380fccf6d09"
+              "group": null,
+              "uuid": "4772c807-7fc2-4575-a278-1e43cdb4c851"
             },
             {
               "@type": "WorkflowStep",
-              "name": "Set Attachments as Processed Email",
+              "name": "Upload File IOCs",
               "description": null,
               "arguments": {
-                "processed_email": "{{vars.email.parsed_attachment_data}}"
+                "params": {
+                  "filename": "{{vars.item.metadata.filename}}",
+                  "file_path": "{{vars.item.file}}",
+                  "create_attachment": false
+                },
+                "version": "3.0.0",
+                "for_each": {
+                  "item": "{{ vars.attachments }}",
+                  "__bulk": false,
+                  "parallel": false,
+                  "condition": ""
+                },
+                "connector": "cyops_utilities",
+                "operation": "upload_file_to_cyops",
+                "operationTitle": "File: Upload a file to CyOPs and Create an Attachment",
+                "step_variables": []
               },
               "status": null,
-              "left": "871",
-              "top": "360",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "7c058837-282b-4eaa-99bb-eb502544cce9"
+              "top": "120",
+              "left": "380",
+              "stepType": "/api/3/workflow_step_types/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+              "group": null,
+              "uuid": "5b050515-1c65-43f8-990f-2a01c2dbee18"
+            }
+          ],
+          "routes": [
+            {
+              "@type": "WorkflowRoute",
+              "name": "Create and Link File Indicators -> Link Indicators",
+              "targetStep": "/api/3/workflow_steps/60431ea2-fdce-4b8c-be96-7971a3bf362c",
+              "sourceStep": "/api/3/workflow_steps/d7a81d72-9552-4321-8bb2-00160b603932",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "a41ca26a-9e84-4669-b841-daff37945e8a"
             },
             {
-              "@type": "WorkflowStep",
-              "name": "Set Processed Email",
-              "description": null,
-              "arguments": {
-                "processed_email": "{{vars.input.params.email}}"
-              },
-              "status": null,
-              "left": "551",
-              "top": "207",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "0d5c18be-e795-40a3-b2c0-ae0444202685"
+              "@type": "WorkflowRoute",
+              "name": "Start -> Upload File IOCs",
+              "targetStep": "/api/3/workflow_steps/5b050515-1c65-43f8-990f-2a01c2dbee18",
+              "sourceStep": "/api/3/workflow_steps/4772c807-7fc2-4575-a278-1e43cdb4c851",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "e437fc87-4c2a-442b-aef8-e2db1e26c0ff"
             },
             {
-              "@type": "WorkflowStep",
-              "name": "Configuration",
-              "description": null,
-              "arguments": {
-                "emlAttachments": "{{vars.input.params.email.attachments  | json_query(\"[?contains(metadata.filename, '.eml')]\") }}",
-                "msgAttachments": "{{vars.input.params.email.attachments  | json_query(\"[?contains(metadata.filename, '.msg')]\") }}"
-              },
-              "status": null,
-              "left": "60",
-              "top": "160",
-              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-              "uuid": "7a61c93c-83e7-4378-9e45-33ebe8018a67"
-            },
+              "@type": "WorkflowRoute",
+              "name": "Upload File IOCs -> Create and Link File Indicators",
+              "targetStep": "/api/3/workflow_steps/d7a81d72-9552-4321-8bb2-00160b603932",
+              "sourceStep": "/api/3/workflow_steps/5b050515-1c65-43f8-990f-2a01c2dbee18",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "3ce9dec3-64dd-4e5d-95eb-8e74cad8824c"
+            }
+          ],
+          "groups": [],
+          "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
+          "uuid": "ec9a21d1-94c0-42af-8a9f-fcdb2e8c4663",
+          "id": 21,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
+          "recordTags": [
+            "dataingestion",
+            "imap"
+          ]
+        },
+        {
+          "@type": "Workflow",
+          "triggerLimit": null,
+          "name": ">> IMAP > Process Email",
+          "aliasName": null,
+          "tag": "#imap #dataingestion",
+          "description": "Extract IMAP Email and checks if msg/eml file is present",
+          "isActive": false,
+          "debug": false,
+          "singleRecordExecution": false,
+          "remoteExecutableFlag": false,
+          "parameters": [
+            "email"
+          ],
+          "synchronous": false,
+          "lastModifyDate": 1579760420,
+          "collection": "/api/3/workflow_collections/aeb40806-3531-487e-b567-15e3b130dec5",
+          "versions": [],
+          "triggerStep": "/api/3/workflow_steps/2f8ea211-977b-4077-8ccf-8380fccf6d09",
+          "steps": [
             {
               "@type": "WorkflowStep",
               "name": "Attachment is msg or eml",
@@ -723,10 +708,74 @@
                 ]
               },
               "status": null,
-              "left": "240",
               "top": "280",
+              "left": "240",
               "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+              "group": null,
               "uuid": "7db55f32-7ba9-43eb-94b2-68d3836c0779"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Configuration",
+              "description": null,
+              "arguments": {
+                "emlAttachments": "{{vars.input.params.email.attachments  | json_query(\"[?contains(metadata.filename, '.eml')]\") }}",
+                "msgAttachments": "{{vars.input.params.email.attachments  | json_query(\"[?contains(metadata.filename, '.msg')]\") }}"
+              },
+              "status": null,
+              "top": "160",
+              "left": "60",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "7a61c93c-83e7-4378-9e45-33ebe8018a67"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Attachments as Processed Email",
+              "description": null,
+              "arguments": {
+                "processed_email": "{{vars.email.parsed_attachment_data}}"
+              },
+              "status": null,
+              "top": "360",
+              "left": "871",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "7c058837-282b-4eaa-99bb-eb502544cce9"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Set Processed Email",
+              "description": null,
+              "arguments": {
+                "processed_email": "{{vars.input.params.email}}"
+              },
+              "status": null,
+              "top": "207",
+              "left": "551",
+              "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
+              "uuid": "0d5c18be-e795-40a3-b2c0-ae0444202685"
+            },
+            {
+              "@type": "WorkflowStep",
+              "name": "Start",
+              "description": null,
+              "arguments": {
+                "step_variables": {
+                  "input": {
+                    "params": {
+                      "email": "{{ vars.email }}"
+                    }
+                  }
+                }
+              },
+              "status": null,
+              "top": "40",
+              "left": "60",
+              "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+              "group": null,
+              "uuid": "2f8ea211-977b-4077-8ccf-8380fccf6d09"
             },
             {
               "@type": "WorkflowStep",
@@ -736,77 +785,87 @@
                 "_temp": "{% for item in vars.email.parsed_attachment_data %}{% set _dummy3=item.update({'reporterEmailBody': vars.email.body}) %}{% set _dummy4=item.update({'reporterEmailAddress': vars.email.headers.from}) %}{% endfor %}"
               },
               "status": null,
-              "left": "540",
               "top": "360",
+              "left": "540",
               "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+              "group": null,
               "uuid": "8820b8ee-f378-48ed-8c71-bca5a912cc1c"
             }
           ],
           "routes": [
             {
               "@type": "WorkflowRoute",
-              "uuid": "4fbc899e-881c-49c6-b1b6-7c205cd08dc8",
-              "name": "Set attachment to variable -> Check attachments for msg or eml",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779",
-              "sourceStep": "/api/3/workflow_steps/7a61c93c-83e7-4378-9e45-33ebe8018a67"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "146289e2-282e-493e-88b2-d5b821084a97",
-              "name": "Start -> Set attachment to variable",
-              "label": null,
-              "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/7a61c93c-83e7-4378-9e45-33ebe8018a67",
-              "sourceStep": "/api/3/workflow_steps/2f8ea211-977b-4077-8ccf-8380fccf6d09"
-            },
-            {
-              "@type": "WorkflowRoute",
-              "uuid": "5bebb781-ec0c-4960-82c3-b200fb41369d",
               "name": "Attachment is msg or eml -> Set Processed Email",
+              "targetStep": "/api/3/workflow_steps/0d5c18be-e795-40a3-b2c0-ae0444202685",
+              "sourceStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779",
               "label": "No",
               "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/0d5c18be-e795-40a3-b2c0-ae0444202685",
-              "sourceStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779"
+              "group": null,
+              "uuid": "5bebb781-ec0c-4960-82c3-b200fb41369d"
             },
             {
               "@type": "WorkflowRoute",
-              "uuid": "d3999c77-390c-4cf7-b298-8af98a5f94cb",
               "name": "Attachment is msg or eml -> Update headers in parsed data",
+              "targetStep": "/api/3/workflow_steps/8820b8ee-f378-48ed-8c71-bca5a912cc1c",
+              "sourceStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779",
               "label": "Yes",
               "isExecuted": false,
-              "targetStep": "/api/3/workflow_steps/8820b8ee-f378-48ed-8c71-bca5a912cc1c",
-              "sourceStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779"
+              "group": null,
+              "uuid": "d3999c77-390c-4cf7-b298-8af98a5f94cb"
             },
             {
               "@type": "WorkflowRoute",
-              "uuid": "58618b2d-ead8-4023-bad1-e89308cf6834",
-              "name": "Update headers in parsed data -> Set Attachments as Processed Email",
+              "name": "Set attachment to variable -> Check attachments for msg or eml",
+              "targetStep": "/api/3/workflow_steps/7db55f32-7ba9-43eb-94b2-68d3836c0779",
+              "sourceStep": "/api/3/workflow_steps/7a61c93c-83e7-4378-9e45-33ebe8018a67",
               "label": null,
               "isExecuted": false,
+              "group": null,
+              "uuid": "4fbc899e-881c-49c6-b1b6-7c205cd08dc8"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Start -> Set attachment to variable",
+              "targetStep": "/api/3/workflow_steps/7a61c93c-83e7-4378-9e45-33ebe8018a67",
+              "sourceStep": "/api/3/workflow_steps/2f8ea211-977b-4077-8ccf-8380fccf6d09",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "146289e2-282e-493e-88b2-d5b821084a97"
+            },
+            {
+              "@type": "WorkflowRoute",
+              "name": "Update headers in parsed data -> Set Attachments as Processed Email",
               "targetStep": "/api/3/workflow_steps/7c058837-282b-4eaa-99bb-eb502544cce9",
-              "sourceStep": "/api/3/workflow_steps/8820b8ee-f378-48ed-8c71-bca5a912cc1c"
+              "sourceStep": "/api/3/workflow_steps/8820b8ee-f378-48ed-8c71-bca5a912cc1c",
+              "label": null,
+              "isExecuted": false,
+              "group": null,
+              "uuid": "58618b2d-ead8-4023-bad1-e89308cf6834"
             }
           ],
-          "versions": [],
-          "lastModifyDate": 1579760420,
+          "groups": [],
           "priority": null,
+          "playbookOrigin": "/api/3/picklists/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+          "isEditable": true,
           "uuid": "eeaf0280-2085-4beb-808b-a9abda63cfad",
+          "id": 22,
+          "owners": [],
+          "isPrivate": false,
+          "deletedAt": null,
+          "importedBy": [],
           "recordTags": [
             "dataingestion",
             "imap"
-          ],
-          "isPrivate": false,
-          "owners": []
+          ]
         }
       ]
     }
   ],
   "exported_tags": [
+    "create",
     "dataingestion",
     "imap",
-    "create",
     "ingest",
     "fetch"
   ]


### PR DESCRIPTION
### Descriptions:
Added an option to save RFC 822 email as an attachment to fetch_email (Useful for customers with cloud Sandbox charging per API call (1 submission instead of several))

#### Fix:
Added an option to save RFC 822 email as an attachment to fetch_email

#### Affected Actions:
- [ ] All
- [ ] Check Health
- [*] Other Actions

#### QA Impact:
- [ ] `full`
- [ ] Test what is prescribed in the Mantis Ticket
- [ ] Regression Impacts
- [ ] Regression Area X
- [ ] Ensure that platform dependencies remain unaffected

#### UTCs:
- [ ] Connector installation verified
- [*] Connector logo verified
- [*] Check health verified
- [ ] Docs link verified
- [*] Actions and Playbooks list verified
- [*] Playbook tags verified
- [ ] All playbooks are in info mode verified
- [ ] All playbooks are in inactive mode verified
- [*] Ingestion playbooks are verified
- [ ] Verified platform dependencies remain unaffected

#### Pytest Test Cases: (If applicable)
- [ ] Attach the test report
